### PR TITLE
Mysql バージョン固定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - TZ=${TZ:-Asia/Tokyo}
 
   db:
-    image: mysql:8.0
+    image: mysql:8.0.15
     volumes:
       - db-store:/var/lib/mysql
       - ./logs:/var/log/mysql
@@ -48,7 +48,7 @@ services:
       - ${DB_PORT:-13306}:3306
 
   db-testing:
-    image: mysql:8.0
+    image: mysql:8.0.15
     volumes:
       - ./docker/mysql/my.cnf:/etc/mysql/conf.d/my.cnf
     tmpfs:


### PR DESCRIPTION
- 既存のdocker-compose.ymlだとビルドのたびにバージョンアップされる
- 2020/02/18時点のバージョン「8.0.19」で設定ファイル「my.cnf」をマウントするとコンテナが落ちる問題が発生

上記問題の解決のため、Mysqlのバージョンを「8.0.15」に固定するように「docker-compose.yml」を編集した。
