### PR TITLE
周辺音楽検索機能の修正

### DIFF
--- a/src/app/Http/Controllers/ArtistsAroundController.php
+++ b/src/app/Http/Controllers/ArtistsAroundController.php
@@ -59,7 +59,6 @@ class ArtistsAroundController extends Controller
                     $responseItem['spotify_artist_id'] = $item['spotify_artist_id'];
                     $responseItem['popularity'] = (int)$item['popularity'];
                     $responseItems[] = $responseItem;
-                    $rankIndex++;
 
                     $historyItem = [];
                     $historyItem['history_id'] = $historyId;
@@ -68,6 +67,8 @@ class ArtistsAroundController extends Controller
                     $historyItem['popularity'] = (int)$item['popularity'];
                     // ArtistAeoundHistory登録
                     ArtistAroundHistory::create($historyItem);
+
+                    $rankIndex++;
                 }
 
 
@@ -110,9 +111,15 @@ class ArtistsAroundController extends Controller
         try {
             $userId = $request->input('userId');
 
+            // ArtistAroundHistoryを子データとして持つHistoryデータのみを取得
             $histories = History::where('user_id', $userId)
-                ->orderBy('created_at', 'desc')
-                ->get();
+                ->with('artistsAroundHistories')
+                ->whereHas('artistsAroundHistories', function ($query) {
+                    $query->whereExists(function ($query) {
+                        return $query;
+                    });
+                })
+                ->orderBy('created_at', 'desc')->get();
 
             foreach ($histories as $history) {
                 $history->artistsAroundHistories;

--- a/src/app/Models/BaseModel.php
+++ b/src/app/Models/BaseModel.php
@@ -34,8 +34,7 @@ class BaseModel extends Model
         $equatorRadius = 6378137.0;
 
         // 全カラム(*)､及び引数で渡された位置情報との距離(distance)を取得するSELECT文
-        $selectStr =<<<___SELECT_SQL___
-        *,
+        $calcDistanceStr =<<<___CALC___
         (? * acos(
             cos(radians(?))
                 *
@@ -46,10 +45,20 @@ class BaseModel extends Model
             sin(radians(?))
                 *
             sin(radians(latitude)))
-        ) AS distance
+        )
+        ___CALC___;
+
+        $selectStr =<<<___SELECT_SQL___
+        *,
+        $calcDistanceStr
         ___SELECT_SQL___;
 
+        $whereStr =<<<___WHERE_SQL___
+        $calcDistanceStr <= ?
+        ___WHERE_SQL___;
+
+
         return $query->selectRaw($selectStr, [$equatorRadius, $latitude, $longitude, $latitude])
-                     ->having('distance', '<=', $distance);
+                     ->whereRaw($whereStr, [$equatorRadius, $latitude, $longitude, $latitude, $distance]);
     }
 }


### PR DESCRIPTION
- 検索時に音楽情報が検索範囲(m)を考慮せずにIDのみで集計されていた問題を修正
- Rank(人気順位)が2番目以降のデータしか検索履歴に登録されていなかった問題を修正
- 検索履歴取得時にTrack,Artist両方の検索履歴が取得されてしまう問題を修正